### PR TITLE
doc: update the link of shizu's hrt guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@
 
 因为总体上变动太大&emsp;包括ui组件和状态管理从底层库到实现的方式都不同了&emsp;交互逻辑也有很大改动&emsp;项目结构也变了(git最不擅长的事)&emsp;加上之前那个太乱了(~~最开始甚至还有计算结果错误的bug&emsp;捂脸~~)&emsp;而且还加了两个平行的模块...&emsp;简单来讲除了算法和大体逻辑和组件结构没变 差不多相当于重写了一遍核心部分&emsp;所以就直接新开了这个repo
 
-现在呢&emsp;有另一位的大佬`しず／shizu`做着类似的事&emsp;她写了一篇包含HRT相关方面的原理和常见方案之类的概述 放在 _~~某不存在的~~_ [Google Slides](https://docs.google.com/presentation/d/1PzE-rmtwBMOrgXcsI~~RIDAKTUIe3fx5h-PmEbzRgBBA/edit?usp=sharing) 上&emsp; 另外qq群 (1075287432) 里有下载好的PDF
+现在呢&emsp;有另一位的大佬`しず／shizu`做着类似的事&emsp;她写了一篇包含HRT相关方面的原理和常见方案之类的概述 放在 [docs.hrt.guide](https://docs.hrt.guide) 上&emsp; 另外qq群 (1075287432) 里有下载好的PDF
 
 最后... 给别人打了那么多广告也要给我自己的群打广告 (1075287432)&emsp;总之就是没啥目的的闲聊群 (~~虽然一开始是想做成音游群的 结果就我一个人打音游...~~)&emsp;所以唯一的特点大概就是氛围好了吧.....


### PR DESCRIPTION
Shizu's HRT Guide 已经迁移到 [docs.hrt.guide](https://docs.hrt.guide), [(GitHub Repo)](https://github.com/BBleae/hrt-book)
的后续更新和维护都将在那里进行